### PR TITLE
listeners: add support for renamed RPA.Browser.Selenium

### DIFF
--- a/robotframework_interpreter/interpreter.py
+++ b/robotframework_interpreter/interpreter.py
@@ -242,7 +242,7 @@ def generate_report(suite: TestSuite, outputdir: str):
 def _execute_impl(code: str, suite: TestSuite, defaults: TestDefaults = TestDefaults(),
                   stdout=None, stderr=None, listeners=[], drivers=[], outputdir=None, interactive_keywords=True):
     # Clear selector completion highlights
-    for driver in yield_current_connection(drivers, ["RPA.Browser", "selenium", "jupyter"]):
+    for driver in yield_current_connection(drivers, ["RPA.Browser.Selenium", "RPA.Browser", "selenium", "jupyter"]):
         try:
             clear_selector_highlights(driver)
         except BrokenOpenConnection:
@@ -382,7 +382,7 @@ def complete(code: str, cursor_pos: int, suite: TestSuite, keywords_listener: Ro
     # Try to complete a CSS selector
     elif is_selector(needle):
         matches = []
-        for driver in yield_current_connection(drivers, ["RPA.Browser", "selenium", "jupyter", "appium"]):
+        for driver in yield_current_connection(drivers, ["RPA.Browser.Selenium", "RPA.Browser", "selenium", "jupyter", "appium"]):
             matches = [get_selector_completions(needle.rstrip(), driver)[0]]
     # Try to complete an AutoIt selector
     elif is_autoit_selector(needle):

--- a/robotframework_interpreter/listeners.py
+++ b/robotframework_interpreter/listeners.py
@@ -204,19 +204,21 @@ class RpaBrowserConnectionsListener:
         self.drivers = drivers
 
     def end_suite(self, name, attributes):
-        try:
-            instance = BuiltIn().get_library_instance("RPA.Browser")
-            clear_drivers(self.drivers, "RPA.Browser")
-            self.drivers.extend(get_webdrivers(instance._drivers, "RPA.Browser"))
-        except RuntimeError:
-            pass
+        for library in ("RPA.Browser.Selenium", "RPA.Browser"):
+            try:
+                instance = BuiltIn().get_library_instance(library)
+                clear_drivers(self.drivers, library)
+                self.drivers.extend(get_webdrivers(instance._drivers, library))
+            except RuntimeError:
+                pass
 
     def start_suite(self, name, attributes):
-        try:
-            instance = BuiltIn().get_library_instance("RPA.Browser")
-            set_webdrivers(self.drivers, instance._drivers, "RPA.Browser")
-        except RuntimeError:
-            pass
+        for library in ("RPA.Browser.Selenium", "RPA.Browser"):
+            try:
+                instance = BuiltIn().get_library_instance(library)
+                set_webdrivers(self.drivers, instance._drivers, library)
+            except RuntimeError:
+                pass
 
 
 class JupyterConnectionsListener:


### PR DESCRIPTION
The library `RPA.Browser` has been renamed to `RPA.Browser.Selenium` in recent versions. This change enables persistence for both versions in the kernel.