### PR TITLE
listeners: more robust check for empty return values

### DIFF
--- a/robotframework_interpreter/listeners.py
+++ b/robotframework_interpreter/listeners.py
@@ -116,12 +116,19 @@ class ReturnValueListener:
         self.return_value = None
 
     def get_last_value(self):
-        if self.return_value is not None and self.return_value != "" and self.return_value != b"":
-            value = to_mime_and_metadata(self.return_value)
+        if not self.has_value(self.return_value):
+            return None
 
-            self.return_value = None
-            return value
-        return None
+        value = to_mime_and_metadata(self.return_value)
+        self.return_value = None
+        return value
+
+    @staticmethod
+    def has_value(value):
+        try:
+            return value is not None and value != "" and value != b""
+        except Exception:
+            return True
 
 
 def clear_drivers(drivers, type_):

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -1,0 +1,21 @@
+from robotframework_interpreter.listeners import ReturnValueListener
+
+
+class CustomClass:
+    def __str__(self):
+        return "A custom class"
+
+
+class RaisesOnCompare:
+    def __eq__(self, _):
+        raise ValueError("Not comparable")
+
+
+def test_result_has_value():
+    assert ReturnValueListener.has_value("string-value")
+    assert ReturnValueListener.has_value(123)
+    assert ReturnValueListener.has_value(CustomClass())
+    assert ReturnValueListener.has_value(RaisesOnCompare())
+    assert not ReturnValueListener.has_value(None)
+    assert not ReturnValueListener.has_value("")
+    assert not ReturnValueListener.has_value(b"")


### PR DESCRIPTION
The result listener filters out empty return values, but some objects override default comparison operators and throw exceptions from them, such as pandas DataFrame. Changed to assume non-empty value if an exception is raised.