### PR TITLE
Use utf-8 encoding for parsing output.xml

### DIFF
--- a/robotframework_interpreter/utils.py
+++ b/robotframework_interpreter/utils.py
@@ -43,7 +43,7 @@ def data_uri(mimetype, data):
 def process_screenshots(outputdir: str):
     cwd = os.getcwd()
 
-    with open(os.path.join(outputdir, "output.xml")) as fp:
+    with open(os.path.join(outputdir, "output.xml"), encoding="utf-8") as fp:
         xml = fp.read()
 
     for src in re.findall('img src="([^"]+)', xml):
@@ -83,7 +83,7 @@ def process_screenshots(outputdir: str):
         )
         xml = xml.replace('img src="{}"'.format(src), 'img src="{}"'.format(uri))
 
-    with open(os.path.join(outputdir, "output.xml"), "w") as fp:
+    with open(os.path.join(outputdir, "output.xml"), "w", encoding="utf-8") as fp:
         fp.write(xml)
 
 


### PR DESCRIPTION
Users - especially on windows - might not have utf-8 as the default system encoding, which is used when opening files in text mode. This will create unnecessary errors when the kernel tries to parse the created output.xml. This commit forces the encoding option.